### PR TITLE
feat: add reusable InputGroup component and custom useForm hook

### DIFF
--- a/src/components/InputGroup.tsx
+++ b/src/components/InputGroup.tsx
@@ -1,0 +1,51 @@
+import type { ChangeEvent } from "react";
+
+interface InputGroupProps {
+  name: string;
+  label: string;
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  error?: string;
+  type?: string;
+  isTextArea?: boolean;
+  rows?: number;
+  className?: string;
+}
+
+export function InputGroup({
+  name,
+  label,
+  value,
+  onChange,
+  error,
+  type = "text",
+  isTextArea = false,
+  rows = 3,
+  className = "",
+}: InputGroupProps) {
+  const InputType = isTextArea ? "textarea" : "input";
+
+  return (
+    <div className={className}>
+      <label
+        htmlFor={name}
+        className="mb-1 block text-sm font-medium text-gray-700"
+      >
+        {label}
+      </label>
+      <InputType
+        autoComplete="off"
+        id={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        rows={isTextArea ? rows : undefined}
+        type={isTextArea ? undefined : type}
+        className={`w-full rounded-md border px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+          error ? "border-red-500" : "border-gray-300"
+        }`}
+      />
+      {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/src/hooks/useForm.tsx
+++ b/src/hooks/useForm.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import type { ChangeEvent, FormEvent } from "react";
+
+export function useForm<T>({
+  initialValues,
+  validate,
+  onSubmit,
+}: {
+  initialValues: T;
+  validate?: (values: T) => Partial<T>;
+  onSubmit: (values: T) => Promise<void> | void;
+}) {
+  const [values, setValues] = useState<T>(initialValues);
+  const [error, setError] = useState<Partial<T>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  useEffect(() => {
+    setValues(initialValues);
+  }, [initialValues]);
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+    setErrors((prev) => ({ ...prev, [name]: null }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (validate) {
+      const newErrors = validate(values);
+      setErrors(newErrors);
+
+      if (Object.keys(newErrors).length > 0) {
+        return;
+      }
+    }
+
+    setIsLoading(true);
+    try {
+      await onSubmit(values);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Something went wrong"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+}


### PR DESCRIPTION
- Implemented InputGroup component with support for text inputs and textareas, including error states and accessibility.
- Added useForm hook to handle form state, validation, error handling, and submission logic.
- Provides a consistent and reusable foundation for building forms across the app.